### PR TITLE
use object-assign instead of soc

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "sinon-chai": "^2.5.0"
   },
   "dependencies": {
-    "soc": "^0.2.0"
+    "object-assign": "^4.0.1"
   }
 }

--- a/src/index.ls
+++ b/src/index.ls
@@ -1,9 +1,4 @@
-soc = require 'soc'
-
-merge = (x, y) ->
-  soc(x)
-    .merge(y)
-    .unwrap!
+merge = require 'object-assign'
 
 descriptor =
   configurable: true
@@ -12,9 +7,8 @@ descriptor =
 
 propsWithDescs = (props, descriptor) ->
   propWithDesc = (prop) ->
-    "#{prop}": soc(value: props[prop])
-      .merge descriptor
-      .unwrap!
+    desc = merge value: props[prop], descriptor
+    "#{prop}": desc
 
   Object.keys props
     .map propWithDesc


### PR DESCRIPTION
soc was adding more boilerplate without the benefits of using soc.
soc is more extending objects through out some control flow structures like if/else.
We weren't using it for that, so object-assign fits better.
